### PR TITLE
Fix provider retry tracking

### DIFF
--- a/Kapok.IpToGeolocation/ServiceCollectionExtensions.cs
+++ b/Kapok.IpToGeolocation/ServiceCollectionExtensions.cs
@@ -22,7 +22,10 @@ namespace Microsoft.Extensions.DependencyInjection
                     if (noContent)
                     {
                         var context = response.RequestMessage.GetPolicyExecutionContext();
-                        context[ContextKey.ProvidersFailed] = context.GetFailedProviders().Concat(new Provider[] { context.GetProvider() });
+                        context[ContextKey.ProvidersFailed] =
+                            context.GetFailedProviders()
+                                .Concat(new[] { context.GetProvider() })
+                                .ToArray();
                     }
 
                     return !successStatusCode || noContent;


### PR DESCRIPTION
## Summary
- correctly store failed providers as array

## Testing
- `dotnet test -l "console;verbosity=normal"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684054927598832d9f8480a388d23713