### PR TITLE
Fix XML docs for Deserialize

### DIFF
--- a/Kapok.IpToGeolocation/GeolocationSerializer.cs
+++ b/Kapok.IpToGeolocation/GeolocationSerializer.cs
@@ -52,7 +52,6 @@ namespace Kapok.IpToGeolocation
         /// </summary>
         /// <param name="source"></param>
         /// <param name="utf8Json"></param>
-        /// <param name="cancellationToken"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException">Thrown when utf8Json or returnType is null.</exception>
         /// <exception cref="JsonException">Thrown when the JSON is invalid or there is remaining data in the string.</exception>


### PR DESCRIPTION
## Summary
- remove cancellationToken from XML docs for `GeolocationSerializer.Deserialize`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684058263d6c832da2a4577e38983694